### PR TITLE
Grupo2 v5: Cliente completo (LLM, razonador e imagen)

### DIFF
--- a/openrouter/grupo2/src/openrouter_app/main.py
+++ b/openrouter/grupo2/src/openrouter_app/main.py
@@ -1,18 +1,51 @@
+import os
+import base64
+import datetime
 from modules.openrouter_client import OpenRouterClient
+
+
+def _images_dir() -> str:
+    base_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+    images_dir = os.path.join(base_dir, "images")
+    os.makedirs(images_dir, exist_ok=True)
+    return images_dir
+
 
 def main():
     client = OpenRouterClient()
+
     print("=== Probando LLM Normal ===")
     prompt_llm = input("Ingresa tu prompt para LLM: ")
-    client.chat_llm(prompt_llm)
+    try:
+        llm_text = client.chat_llm(prompt_llm)
+        print(f"Respuesta LLM:\n{llm_text}")
+    except ValueError as e:
+        print(f"Error LLM: {e}")
 
     print("\n=== Probando Razonador ===")
     prompt_reasoner = input("Ingresa tu prompt para Razonador: ")
-    client.chat_reasoner(prompt_reasoner)
+    try:
+        reason_text = client.chat_reasoner(prompt_reasoner)
+        print(f"Respuesta Razonador:\n{reason_text}")
+    except ValueError as e:
+        print(f"Error Razonador: {e}")
 
     print("\n=== Probando Generación de Imagen ===")
     prompt_image = input("Ingresa tu prompt para Imagen: ")
-    client.generate_image(prompt_image)
+    try:
+        image_url = client.generate_image(prompt_image)
+        print(f"URL devuelta: {image_url}")
+        if isinstance(image_url, str) and image_url.startswith("data:image"):
+            header, data = image_url.split(',', 1)
+            img_data = base64.b64decode(data)
+            ts = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+            out_path = os.path.join(_images_dir(), f"imagen_{ts}.png")
+            with open(out_path, 'wb') as f:
+                f.write(img_data)
+            print(f"Imagen guardada en: {out_path}")
+    except ValueError as e:
+        print(f"Error Imagen: {e}")
+
 
 if __name__ == "__main__":
     main()

--- a/openrouter/grupo2/src/openrouter_app/modules/openrouter_client.py
+++ b/openrouter/grupo2/src/openrouter_app/modules/openrouter_client.py
@@ -4,44 +4,58 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
 class OpenRouterClient:
+    """Cliente para la API de OpenRouter con LLM, razonador e imagen."""
+
     def __init__(self, api_key: str = None):
         if api_key is None:
             api_key = os.getenv('OPENROUTER_API_KEY')
         if not api_key:
             raise ValueError("Se requiere una API key válida.")
-        
+
         self.base_url = "https://openrouter.ai/api/v1/chat/completions"
         self.headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json"
         }
-    
-    def _make_request(self, model, messages):
+
+    def _make_request(self, model: str, messages: list, extra_params: dict | None = None) -> dict:
+        """Request POST reutilizable con manejo de errores básico."""
         payload = {
             "model": model,
             "messages": messages
         }
-        response = requests.post(self.base_url, headers=self.headers, json=payload)
-        return response.json()
-    
-    def chat_llm(self, prompt):
-        model = "google/gemini-2.0-flash-lite-001"
+        if extra_params:
+            payload.update(extra_params)
+
+        try:
+            response = requests.post(self.base_url, headers=self.headers, json=payload)
+            response.raise_for_status()
+            data = response.json()
+            if isinstance(data, dict) and data.get("error"):
+                raise ValueError(f"Error de API: {data['error']}")
+            return data
+        except requests.exceptions.RequestException as e:
+            raise ValueError(f"Error en request: {e}")
+
+    def chat_llm(self, prompt: str) -> str:
+        """Devuelve solo el texto de respuesta del LLM."""
         messages = [{"role": "user", "content": prompt}]
         response = self._make_request(model, messages)
-        print(f"Respuesta completa: {response}")
-    
-    def chat_reasoner(self, prompt):
-        model = "microsoft/phi-4-reasoning-plus"
+        return response["choices"][0]["message"]["content"]
+
+    def chat_reasoner(self, prompt: str) -> str:
+        """Devuelve solo el texto de respuesta del modelo razonador."""
+        model = "openai/gpt-oss-20b:free"
         messages = [{"role": "user", "content": prompt}]
         response = self._make_request(model, messages)
-        print(f"Simulando razonador con prompt: {response}")
-    
+        return response["choices"][0]["message"]["content"]
+
     def generate_image(self, prompt: str) -> str:
-    
-        model = "openai/gpt-5-image-mini"
-        
+        """Devuelve la URL (o data URL) de la primera imagen generada."""
+        model = "google/gemini-2.5-flash-image"
         messages = [{"role": "user", "content": prompt}]
-        
-        response_json = self._make_request(model, messages)
-        print((response_json))
+        extra_params = {"modalities": ["image", "text"]}
+        response = self._make_request(model, messages, extra_params)
+        return response["choices"][0]["message"]["images"][0]["image_url"]["url"]


### PR DESCRIPTION
- LLM: devuelve solo texto (google/gemini-2.0-flash-lite-001)
- Razonador: openai/gpt-oss-20b:free
- Imagen: google/gemini-2.5-flash-image con modalities; guarda data URL como PNG
- _make_request con raise_for_status y detección de error
- main con prompts, salida limpia y guardado en openrouter/images/
- Requiere OPENROUTER_API_KEY; deps: requests, python-dotenv