### PR TITLE
fix: añade timeout a requests.post en _make_request para evitar bloqueos indefinidos

### DIFF
--- a/openrouter/grupo2/src/openrouter_app/modules/openrouter_client.py
+++ b/openrouter/grupo2/src/openrouter_app/modules/openrouter_client.py
@@ -30,7 +30,7 @@ class OpenRouterClient:
             payload.update(extra_params)
 
         try:
-            response = requests.post(self.base_url, headers=self.headers, json=payload)
+            response = requests.post(self.base_url, headers=self.headers, json=payload, timeout=30)
             response.raise_for_status()
             data = response.json()
             if isinstance(data, dict) and data.get("error"):


### PR DESCRIPTION
Este PR soluciona el problema de peticiones HTTP sin timeout en el cliente OpenRouter. Ahora todas las llamadas a requests.post en _make_request tienen timeout=30 para evitar bloqueos indefinidos si la API no responde.